### PR TITLE
🐛 fix(script): add utils/docs to PYTHONPATH for llvm_sphinx import

### DIFF
--- a/cmake/targets/sphinx_build_docs.cmake
+++ b/cmake/targets/sphinx_build_docs.cmake
@@ -75,7 +75,7 @@ foreach(_LANGUAGE ${LANGUAGE_LIST})
     if (CMAKE_HOST_LINUX)
         set(ENV_PATH                "${PROJ_CONDA_DIR}/bin:$ENV{PATH}")
         set(ENV_LD_LIBRARY_PATH     "${PROJ_CONDA_DIR}/lib:$ENV{LD_LIBRARY_PATH}")
-        set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}")
+        set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}:${PROJ_OUT_REPO_DIR}/utils/docs")
         set(ENV_VARS_OF_SYSTEM      PATH=${ENV_PATH}
                                     LD_LIBRARY_PATH=${ENV_LD_LIBRARY_PATH}
                                     PYTHONPATH=${ENV_PYTHONPATH})
@@ -85,7 +85,8 @@ foreach(_LANGUAGE ${LANGUAGE_LIST})
                                     "${PROJ_CONDA_DIR}/Library/bin"
                                     "${PROJ_CONDA_DIR}"
                                     "$ENV{PATH}")
-        set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}")
+        set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}"
+                                    "${PROJ_OUT_REPO_DIR}/utils/docs")
         string(REPLACE ";" "\\\\;" ENV_PATH "${ENV_PATH}")
         string(REPLACE ";" "\\\\;" ENV_PYTHONPATH "${ENV_PYTHONPATH}")
         set(ENV_VARS_OF_SYSTEM      PATH=${ENV_PATH}

--- a/cmake/targets/sphinx_update_pot.cmake
+++ b/cmake/targets/sphinx_update_pot.cmake
@@ -246,7 +246,7 @@ message(STATUS "Running 'sphinx-build' command with 'gettext' builder to generat
 if (CMAKE_HOST_LINUX)
     set(ENV_PATH                "${PROJ_CONDA_DIR}/bin:$ENV{PATH}")
     set(ENV_LD_LIBRARY_PATH     "${PROJ_CONDA_DIR}/lib:$ENV{LD_LIBRARY_PATH}")
-    set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}")
+    set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}:${PROJ_OUT_REPO_DIR}/utils/docs")
     set(ENV_VARS_OF_SYSTEM      PATH=${ENV_PATH}
                                 LD_LIBRARY_PATH=${ENV_LD_LIBRARY_PATH}
                                 PYTHONPATH=${ENV_PYTHONPATH})
@@ -256,7 +256,8 @@ elseif (CMAKE_HOST_WIN32)
                                 "${PROJ_CONDA_DIR}/Library/bin"
                                 "${PROJ_CONDA_DIR}"
                                 "$ENV{PATH}")
-    set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}")
+    set(ENV_PYTHONPATH          "${PROJ_OUT_REPO_DOCS_EXTNS_DIR}"
+                                "${PROJ_OUT_REPO_DIR}/utils/docs")
     string(REPLACE ";" "\\\\;" ENV_PATH "${ENV_PATH}")
     string(REPLACE ";" "\\\\;" ENV_PYTHONPATH "${ENV_PYTHONPATH}")
     set(ENV_VARS_OF_SYSTEM      PATH=${ENV_PATH}


### PR DESCRIPTION
Since llvm/llvm-project@42ff45b865b introduced the llvm_sphinx module under utils/docs/, add it to PYTHONPATH so Sphinx can import it. Fixes:

    ModuleNotFoundError: No module named 'llvm_sphinx'