### PR TITLE
🎨 style(readme): use shields.io workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
   <tbody>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-sphinx-build-docs.yml" ><img alt="ci-sphinx-build-docs" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-sphinx-build-docs.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-sphinx-build-docs.yml" ><img alt="ci-sphinx-build-docs" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-sphinx-build-docs.yml?logo=github&style=flat&label=ci-sphinx-build-docs" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Build documents by Sphinx and upload build artifacts.</div>
@@ -173,7 +173,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-sphinx-update-pot.yml" ><img alt="ci-sphinx-update-pot" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-sphinx-update-pot.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-sphinx-update-pot.yml" ><img alt="ci-sphinx-update-pot" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-sphinx-update-pot.yml?logo=github&style=flat&label=ci-sphinx-update-pot" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update <code>.pot</code> files by Sphinx with <code>gettext</code> builder.</div>
@@ -181,7 +181,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-update-po.yml" ><img alt="ci-gettext-update-po" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-update-po.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-update-po.yml" ><img alt="ci-gettext-update-po" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-gettext-update-po.yml?logo=github&style=flat&label=ci-gettext-update-po" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update <code>.po</code> files from <code>.pot</code> files by Gettext toolkit.</div>
@@ -189,7 +189,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-compendium.yml"><img alt="ci-gettext-compendium" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-compendium.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-compendium.yml"><img alt="ci-gettext-compendium" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-gettext-compendium.yml?logo=github&style=flat&label=ci-gettext-compendium" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update <code>.po</code> files from the compendium by Gettext toolkit.</div>
@@ -197,7 +197,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-statistics.yml"><img alt="ci-gettext-statistics" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-statistics.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-gettext-statistics.yml"><img alt="ci-gettext-statistics" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-gettext-statistics.yml?logo=github&style=flat&label=ci-gettext-statistics" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update statistics information of <code>.po</code> files by Gettext toolkit.</div>
@@ -205,7 +205,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-upload-pot.yml"><img alt="ci-crowdin-upload-pot" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-upload-pot.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-upload-pot.yml"><img alt="ci-crowdin-upload-pot" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-crowdin-upload-pot.yml?logo=github&style=flat&label=ci-crowdin-upload-pot" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Upload <code>.pot</code> files to Crowdin by its CLI tool.</div>
@@ -213,7 +213,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-download-po.yml"><img alt="ci-crowdin-download-po" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-download-po.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-download-po.yml"><img alt="ci-crowdin-download-po" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-crowdin-download-po.yml?logo=github&style=flat&label=ci-crowdin-download-po" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Download <code>.po</code> files from Crowdin by its CLI tool.</div>
@@ -221,7 +221,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-update-readme.yml"><img alt="ci-crowdin-update-readme" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-update-readme.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-crowdin-update-readme.yml"><img alt="ci-crowdin-update-readme" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-crowdin-update-readme.yml?logo=github&style=flat&label=ci-crowdin-update-readme" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update README translations by Crowdin CLI tool.</div>
@@ -229,7 +229,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-deploy-pages.yml"><img alt="ci-deploy-pages" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-deploy-pages.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-deploy-pages.yml"><img alt="ci-deploy-pages" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-deploy-pages.yml?logo=github&style=flat&label=ci-deploy-pages" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Download and deploy build artifacts to <code>pages</code> branch.</div>
@@ -237,7 +237,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-deploy-po-version.yml"><img alt="ci-deploy-po-version" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-deploy-po-version.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-deploy-po-version.yml"><img alt="ci-deploy-po-version" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-deploy-po-version.yml?logo=github&style=flat&label=ci-deploy-po-version" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Deploy <code>.po</code> files to <code>po/${VERSION}</code> branch.</div>
@@ -245,7 +245,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-contributors.yml"><img alt="ci-update-contributors" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-contributors.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-contributors.yml"><img alt="ci-update-contributors" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-update-contributors.yml?logo=github&style=flat&label=ci-update-contributors" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update contributors <code>.svg</code> files to <code>static</code> branch.</div>
@@ -253,7 +253,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-license-year.yml"><img alt="ci-update-license-year" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-license-year.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-license-year.yml"><img alt="ci-update-license-year" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-update-license-year.yml?logo=github&style=flat&label=ci-update-license-year" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update the copyright year in LICENSE to the current year.</div>
@@ -261,7 +261,7 @@ The goal of this project is to translate The LLVM Documentation into multiple la
     </tr>
     <tr>
       <td rowspan="1" colspan="1" align="right" style="text-align: right;">
-        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-submodule.yml"><img alt="ci-update-submodule" src="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-submodule.yml/badge.svg" /></a></div>
+        <div><a href="https://github.com/localizethedocs/llvm-docs-l10n/actions/workflows/ci-update-submodule.yml"><img alt="ci-update-submodule" src="https://img.shields.io/github/actions/workflow/status/localizethedocs/llvm-docs-l10n/ci-update-submodule.yml?logo=github&style=flat&label=ci-update-submodule" /></a></div>
       </td>
       <td rowspan="1" colspan="1" align="left" style="text-align: left;">
         <div>Update each of the submodules to their latest commit.</div>


### PR DESCRIPTION
Replace GitHub-native badge.svg URLs with shields.io github-actions-workflow-status badges.

Synced from: localizethedocs/cmake-docs-l10n@e3f9a69a10bcfed1d4daef402caebae51150105e