### PR TITLE
🐛 fix(script): update provenance insert point

### DIFF
--- a/cmake/targets/sphinx_build_docs.cmake
+++ b/cmake/targets/sphinx_build_docs.cmake
@@ -211,7 +211,7 @@ restore_cmake_message_indent()
 
 set(UPSTREAM_DOCS   "https://llvm.org/docs")
 set(UPSTREAM_REPO   "https://github.com/llvm/llvm-project")
-set(INSERT_POINT    "div[role=\"main\"]")
+set(INSERT_POINT    "div[class=\"article-container\"]")
 
 
 message(STATUS "Configuring 'ltd-provenance.js' file to the version subdir of the builder directory...")


### PR DESCRIPTION
Update the provenance insertion point from `div[role="main"]` to `div[class="article-container"]` to match the furo theme used by the upstream LLVM documentation.